### PR TITLE
Add admin tools

### DIFF
--- a/app/Resources/views/admin/users.html.twig
+++ b/app/Resources/views/admin/users.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block title %}
-    ACM at UCR | Admin
+    ACM at UCR | Admin Users
 {% endblock %}
 
 {% block head %}
@@ -23,6 +23,7 @@
 	<script src="{{ asset('js/index/util.js') }}"></script>
 	<!--[if lte IE 8]><script src="{{ asset('js/index/ie/respond.min.js') }}"></script><![endif]-->
 	<script src="{{ asset('js/index/main.js') }}"></script>
+    <script src="{{ asset('js/admin/users.js') }}"></script>
 {% endblock %}
 
 {% block body %}
@@ -36,33 +37,34 @@
 		<div id="main">
 			<!-- Post -->
 			<article class="post">
-                <h1> Admin home! </h1>
+                <h1> Site User Accounts </h1>
                 <hr />
-                <h3> Posts </h3>
-                <p>
-                    <a href={{ path('event_new') }} class="button big new_post_button"> New Event </a>
-                    Create a new upcoming event. Before creating, make sure you have also made the event on Facebook.
-                </p>
-                <p>
-                    <a href={{ path('new_post') }} class="button big new_post_button"> New Post </a>
-                    Create a new post! 
-                </p>
-                <hr />
-                <h3> Events </h3>
-                <p>
-                    <a href={{ path('swiper_home') }} class="button big new_post_button"> Card Swiper </a>
-                    Take attendance for an event!
-                </p>
-                <p>
-                    <a href={{ path('events_attendance') }} class="button big new_post_button"> Attendance </a>
-                    See attendance for past events
-                </p>
-                <hr />
-                <h3> Users </h3>
-                <p>
-                    <a href={{ path('admin_users') }} class="button big new_post_button"> Users </a>
-                    See user info pages as well as manage permissions. 
-                </p>
+                {% if users|length == 0 %}
+                    <h4> No users are registered. </h4>
+                {% else %}
+        			<table>
+                        <thead>
+                            <td width="50px"> # </td>
+                            <td> Name </td>
+                            <td> Roles </td>
+                            <td> Options </td>
+                        </thead>
+                        {% for user in users %}
+                        <tr>
+                            <td> {{ loop.index }} </td>
+                            <td> {{ user.name }} </td>
+                            <td> {{ user.getRolesString }} </td>
+                            <td> 
+                                {% if 'ROLE_ADMIN' in user.getRolesString %}
+                                    <a data-user-id='{{ user.id }}' class="button small make_admin_button"> Make Admin </a>
+                                {% else %}
+                                    <span><i> None </i></span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </table>
+                {% endif %}
 			</article>
 		</div>
 	</div>

--- a/app/Resources/views/admin/users.html.twig
+++ b/app/Resources/views/admin/users.html.twig
@@ -53,12 +53,16 @@
                         <tr>
                             <td> {{ loop.index }} </td>
                             <td> {{ user.name }} </td>
-                            <td> {{ user.getRolesString }} </td>
-                            <td> 
-                                {% if 'ROLE_ADMIN' in user.getRolesString %}
+                            {% if 'ROLE_ADMIN' in user.getRolesString %}
+                                <td> <b>{{ user.getRolesString }}</b> </td>
+                            {% else %}
+                                <td> {{ user.getRolesString }} </td>
+                            {% endif %}
+                            <td>
+                                {% if 'ROLE_ADMIN' not in user.getRolesString %}
                                     <a data-user-id='{{ user.id }}' class="button small make_admin_button"> Make Admin </a>
                                 {% else %}
-                                    <span><i> None </i></span>
+                                    <a data-user-id='{{ user.id }}' class="button small make_user_button"> Revoke Admin </a>
                                 {% endif %}
                             </td>
                         </tr>
@@ -69,4 +73,8 @@
 		</div>
 	</div>
 </div>
+<<<<<<< HEAD
 {% endblock body %}
+=======
+{% endblock body %}
+>>>>>>> Adding changes to allow admins to be added via web tool

--- a/app/Resources/views/events/edit.html.twig
+++ b/app/Resources/views/events/edit.html.twig
@@ -37,7 +37,6 @@
 			<!-- Post -->
     		<article class="post">
                 <h1>Edit Event</h1>
-
                 {{ form_start(edit_form) }}
                     {{ form_row(edit_form.title) }}
                     {{ form_row(edit_form.eventUrl) }}

--- a/bin/symfony_requirements
+++ b/bin/symfony_requirements
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-require_once dirname(__FILE__).'/../var/SymfonyRequirements.php';
+require_once dirname(__FILE__).'/./SymfonyRequirements.php';
 
 $lineSize = 70;
 $symfonyRequirements = new SymfonyRequirements();

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -20,4 +20,26 @@ class AdminController extends Controller
             
         ]);
     }
+    
+    /**
+     * @Route("/users", name="admin_users")
+     */
+    public function adminUsersAction(Request $request)
+    {
+        $em = $this->get('doctrine')->getManager();
+        $users = $em->getRepository('AppBundle\Entity\User')
+                    ->findAll();
+        
+        return $this->render('admin/users.html.twig', [
+            'users' => $users,
+        ]);
+    }
+    
+    /**
+     * @Route("/users/make_admin", name="admin_make_admin")
+     */
+    public function adminMakeAdminAction(Request $request)
+    {
+
+    }
 }

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -5,6 +5,7 @@ namespace AppBundle\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * @Route("/admin")
@@ -17,10 +18,10 @@ class AdminController extends Controller
     public function adminHomeAction(Request $request)
     {
         return $this->render('admin/index.html.twig', [
-            
+
         ]);
     }
-    
+
     /**
      * @Route("/users", name="admin_users")
      */
@@ -29,17 +30,60 @@ class AdminController extends Controller
         $em = $this->get('doctrine')->getManager();
         $users = $em->getRepository('AppBundle\Entity\User')
                     ->findAll();
-        
+
         return $this->render('admin/users.html.twig', [
             'users' => $users,
         ]);
     }
-    
+
     /**
      * @Route("/users/make_admin", name="admin_make_admin")
      */
     public function adminMakeAdminAction(Request $request)
     {
+      $em = $this->get('doctrine')->getManager();
+      $user_id = $request->request->get('user_id');
+      $user = $em->getRepository('AppBundle\Entity\User')->find($user_id);
 
+      if (!$user) {
+        return new JsonResponse([
+          'msg' => 'Could not locate user with the given id',
+        ], 400);
+      }
+
+      $user_name = $user->getName();
+      $user->setRole('ROLE_ADMIN');
+      $em->persist($user);
+      $em->flush();
+
+      return new JsonResponse([
+        'msg' => "Added $user_name as admin.",
+      ]);
+    }
+
+    /**
+     * @Route("/users/revoke_admin", name="admin_revoke_admin")
+     */
+    public function adminRevokeAdminAction(Request $request)
+    {
+
+      $em = $this->get('doctrine')->getManager();
+      $user_id = $request->request->get('user_id');
+      $user = $em->getRepository('AppBundle\Entity\User')->find($user_id);
+
+      if (!$user) {
+        return new JsonResponse([
+          'msg' => 'Could not locate user with the given id',
+        ], 400);
+      }
+
+      $user_name = $user->getName();
+      $user->setRole('ROLE_USER');
+      $em->persist($user);
+      $em->flush();
+
+      return new JsonResponse([
+        'msg' => "Revoked admin rights from $user_name.",
+      ]);
     }
 }

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -155,6 +155,11 @@ class User implements UserInterface, \Serializable
     {
         return array($this->role);
     }
+    
+    public function getRolesString()
+    {
+        return implode(", ", array($this->role));
+    }
 
     public function eraseCredentials()
     {

--- a/web/config.php
+++ b/web/config.php
@@ -22,7 +22,7 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
     exit('This script is only accessible from localhost.');
 }
 
-require_once dirname(__FILE__).'/../var/SymfonyRequirements.php';
+require_once dirname(__FILE__).'/./SymfonyRequirements.php';
 
 $symfonyRequirements = new SymfonyRequirements();
 

--- a/web/js/admin/users.js
+++ b/web/js/admin/users.js
@@ -1,0 +1,23 @@
+$(".make_admin_button").on('click', function(e) {
+  let user_id = $(this).attr('data-user-id');
+  confirmation = confirm("Are you sure you'd like to make them an admin?");
+  if(confirmation) {
+    make_admin(user_id);
+  }
+  e.preventDefault();
+});
+
+function make_admin(user_id) {
+    alert("This user has ID of: " + user_id);
+    $.post('/admin/users/make_admin', {
+      user_id: user_id,
+    }, function(data, status, xhr) {
+      
+    }).fail(function(data, status, xhr) {
+      if (xhr.status === 420) {
+        alert("Error: User is already an admin.");
+      } else {
+        alert("Error: Unable to add admin: " + );
+      }
+    });
+}

--- a/web/js/admin/users.js
+++ b/web/js/admin/users.js
@@ -7,17 +7,43 @@ $(".make_admin_button").on('click', function(e) {
   e.preventDefault();
 });
 
+$(".make_user_button").on('click', function(e) {
+  let user_id = $(this).attr('data-user-id');
+  confirmation = confirm("Are you sure you'd like to revoke admin rights?");
+  if(confirmation) {
+    revoke_admin(user_id);
+  }
+  e.preventDefault();
+});
+
+function revoke_admin(user_id) {
+    $.post('/admin/users/revoke_admin', {
+      user_id: user_id,
+    }, function(data, status, xhr) {
+      alert(data.msg);
+      location.reload();
+    }).fail(function(data, status, xhr) {
+      if (xhr.status === 420) {
+        alert("Error: User is already a user.");
+      } else {
+        alert("Error: Unable to revoke admin rights.");
+      }
+      location.reload();
+    });
+}
+
 function make_admin(user_id) {
-    alert("This user has ID of: " + user_id);
     $.post('/admin/users/make_admin', {
       user_id: user_id,
     }, function(data, status, xhr) {
-      
+      alert(data.msg);
+      location.reload();
     }).fail(function(data, status, xhr) {
       if (xhr.status === 420) {
         alert("Error: User is already an admin.");
       } else {
-        alert("Error: Unable to add admin: " + );
+        alert("Error: Unable to add admin.");
       }
+      location.reload();
     });
 }


### PR DESCRIPTION
# Summary
Created new admin page `admin/users`
Allows you to see the role of all users that have signed up for accounts on the site
Click 'Add Admin' to promote the specified user to `ROLE_ADMIN`.
Click 'Revoke Admin' to demote the specified user to `ROLE_USER`. 

# Test plan
Tested locally

### Screenshots
Before:
![Before](https://i.imgur.com/aQGa9jR.png)

After:
![After](https://i.imgur.com/wJJ5mGR.png)